### PR TITLE
Fix colab links in docs noteboooks

### DIFF
--- a/docs/notebooks/array_visualization.ipynb
+++ b/docs/notebooks/array_visualization.ipynb
@@ -28,7 +28,7 @@
     "id": "USGIPdLYDzSo"
    },
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/treescope/blob/main/notebooks/array_visualization.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google-deepmind/treescope/blob/main/notebooks/array_visualization.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/treescope/blob/main/docs/notebooks/array_visualization.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google-deepmind/treescope/blob/main/docs/notebooks/array_visualization.ipynb)"
    ]
   },
   {

--- a/docs/notebooks/building_custom_visualizations.ipynb
+++ b/docs/notebooks/building_custom_visualizations.ipynb
@@ -28,7 +28,7 @@
     "id": "USGIPdLYDzSo"
    },
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/treescope/blob/main/notebooks/building_custom_visualizers.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google-deepmind/treescope/blob/main/notebooks/building_custom_visualizers.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/treescope/blob/main/docs/notebooks/building_custom_visualizers.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google-deepmind/treescope/blob/main/docs/notebooks/building_custom_visualizers.ipynb)"
    ]
   },
   {

--- a/docs/notebooks/pretty_printing.ipynb
+++ b/docs/notebooks/pretty_printing.ipynb
@@ -28,7 +28,7 @@
     "id": "USGIPdLYDzSo"
    },
    "source": [
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/treescope/blob/main/notebooks/pretty_printing.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google-deepmind/treescope/blob/main/notebooks/pretty_printing.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google-deepmind/treescope/blob/main/docs/notebooks/pretty_printing.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/google-deepmind/treescope/blob/main/docs/notebooks/pretty_printing.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
The current colab links in the docs notebooks do not correctly path to the src notebook (which live in `docs/` rather than in the project root), leading interested users to a `404`.

This branch's diffs corrects the colab links to the src notebook path.


#### Reference

<details>
  <summary>The error screen encountered when attempting to open the custom visualizers colab:</summary>

![screencap_2024-07-26_14-30-02](https://github.com/user-attachments/assets/c76a9da1-101f-49c0-be2c-5f9e8e6c101f)

</details>



