### PR TITLE
Modify Torch Support to handle tensors on GPU

### DIFF
--- a/treescope/external/torch_support.py
+++ b/treescope/external/torch_support.py
@@ -79,7 +79,7 @@ def _truncate_and_copy(
     assert (
         len(prefix_slices) == len(array_source.shape) == len(array_dest.shape)
     )
-    array_dest[prefix_slices] = array_source[prefix_slices].numpy()
+    array_dest[prefix_slices] = array_source[prefix_slices].numpy(force=True)
   else:
     # Recursive step.
     axis = len(prefix_slices)
@@ -145,7 +145,7 @@ class TorchTensorAdapter(ndarray_adapters.NDArrayAdapter[torch.Tensor]):
 
     if edge_items_per_axis == (None,) * array.ndim:
       # No truncation.
-      return array.numpy(), mask.numpy()
+      return array.numpy(force=True), mask.numpy(force=True)
 
     dest_shape = [
         size if edge_items is None else 2 * edge_items + 1


### PR DESCRIPTION
It seems the torch support assumed tensors exist on CPU, as this is a pre-requisite for conversion to numpy arrays with `some_tensor.numpy()`. Perhaps this was an intentional design choice to avoid occupying non-accelerator memory for users who aren't being careful, but moving non-cpu tensors onto cpu automatically for the purposes of visualization is likely acceptable in most use cases, so I have added this.

Minor note that the .cpu() and .detach() conversion can be combined into one-line. Not sure what is preferable.