### PR TITLE
add "part" attribute to treescope_root

### DIFF
--- a/treescope/lowering.py
+++ b/treescope/lowering.py
@@ -321,6 +321,7 @@ def _render_to_html_as_root_streaming(
     classnames += " roundtrip_mode"
   stream.write(
       f'<div class="{classnames}" tabindex="0" '
+      'part="treescope_root" '
       'onkeydown="this.getRootNode().host.defns'
       '.toggle_root_roundtrip(this, event)">'
   )


### PR DESCRIPTION
Adding a `"part"` attribute to the root element would allow users of Treescope to target content in the shadow DOM with CSS rules, eg.

```css
treescope-container::part(treescope_root) {
  font-family: Inconsolata;
}
```

(context: we use Treescope in our documentation website, and would like consistent style/formatting)