### PR TITLE
Enable pyink on tests, fix VSCode pyink config to avoid bad Python version.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Check formatting
     - name: Check pyink formatting
-      run: uv run pyink treescope --check
+      run: uv run pyink treescope tests --check
 
     - name: Run pylint
       run: uv run pylint treescope

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,6 @@
         "editor.detectIndentation": false,
         "editor.defaultFormatter": "ms-python.black-formatter",
     },
-    "black-formatter.path": ["uvx", "pyink"],
+    "black-formatter.path": ["uvx", "--python=>=3.9,!=3.12.5", "pyink"],
     "pylint.enabled": true,
 }

--- a/tests/fixtures/treescope_examples_fixture.py
+++ b/tests/fixtures/treescope_examples_fixture.py
@@ -206,6 +206,7 @@ class ObjectWithCustomHandlerThatThrowsDeferred:
 
   def __treescope_repr__(self, path, subtree_renderer):
     del path, subtree_renderer
+
     def _internal_main_thunk(layout_decision):
       del layout_decision
       raise RuntimeError("Simulated deferred treescope_repr failure!")

--- a/tests/representation_test.py
+++ b/tests/representation_test.py
@@ -156,7 +156,9 @@ class RepresentationPartsTest(parameterized.TestCase):
           expected_text_roundtrip_collapsed='some text with characters < > &',
           expected_text_roundtrip_expanded='some text with characters < > &',
           expected_html='some text with characters &lt; &gt; &amp;',
-          expected_html_at_beginning='some text with characters &lt; &gt; &amp;',
+          expected_html_at_beginning=(
+              'some text with characters &lt; &gt; &amp;'
+          ),
       ),
       dict(
           testcase_name='siblings',

--- a/treescope/_internal/api/arrayviz.py
+++ b/treescope/_internal/api/arrayviz.py
@@ -223,9 +223,9 @@ def render_array(
         something like ``palettable.matplotlib.Inferno_20.colors``.
       truncate: Whether or not to truncate the array to a smaller size before
         rendering.
-      maximum_size: Maximum number of elements of an array to show. Arrays larger
-        than this will be truncated along one or more axes. Ignored unless
-        ``truncate`` is True.
+      maximum_size: Maximum number of elements of an array to show. Arrays
+        larger than this will be truncated along one or more axes. Ignored
+        unless ``truncate`` is True.
       cutoff_size_per_axis: Maximum number of elements of each individual axis
         to show without truncation. Any axis longer than this will be truncated,
         with their visual size increasing logarithmically with the true axis

--- a/treescope/_internal/handlers/shared_value_postprocessor.py
+++ b/treescope/_internal/handlers/shared_value_postprocessor.py
@@ -215,9 +215,13 @@ class WithDynamicSharedPip(basic_parts.DeferringToChild):
                 {{
                     padding-right: 1ch;
                     margin-right: -0.5ch;
-                    background: linear-gradient(135deg, orange 0 0.6ch, transparent 0.6ch );
+                    background: linear-gradient(
+                        135deg, orange 0 0.6ch, transparent 0.6ch
+                    );
                 }}
-                .shared_warning_pip.is_first_on_line:not({setup_context.collapsed_selector} *)
+                .shared_warning_pip.is_first_on_line:not(
+                    {setup_context.collapsed_selector} *
+                )
                 {{
                     margin-left: -0.5ch;
                 }}

--- a/treescope/_internal/html_encapsulation.py
+++ b/treescope/_internal/html_encapsulation.py
@@ -356,9 +356,9 @@ def encapsulate_streaming_html(
     stream = io.StringIO()
 
   if stealable:
-    stealer_content = _prep_html_js_and_strip_comments(STEALER_TEMPLATE).replace(
-        "{__REPLACE_ME_WITH_CONTAINER_ID_CLASS__}", unique_id_class
-    )
+    stealer_content = _prep_html_js_and_strip_comments(
+        STEALER_TEMPLATE
+    ).replace("{__REPLACE_ME_WITH_CONTAINER_ID_CLASS__}", unique_id_class)
     yield HTMLOutputSegment(
         html_src=stealer_content,
         segment_type=SegmentType.FINAL_OUTPUT_STEALER,

--- a/treescope/_internal/parts/basic_parts.py
+++ b/treescope/_internal/parts/basic_parts.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Hashable
 import dataclasses
 import functools
 import html
@@ -24,7 +25,7 @@ import io
 import itertools
 import operator
 import typing
-from typing import Any, Hashable, Sequence
+from typing import Any, Sequence
 
 from treescope._internal import html_escaping
 from treescope._internal.parts import part_interface

--- a/treescope/external/jax_support.py
+++ b/treescope/external/jax_support.py
@@ -409,12 +409,14 @@ def _summarize_array_data_unconditionally(array: jax.Array) -> list[str]:
     stat = compute_summary(array, is_floating, is_integer, is_bool)
     # Get values in parallel.
     stat = jax.device_get(stat)
+    # pylint: disable=inconsistent-quotes
     if is_floating and stat["any_finite"]:
       output_parts.append(f" ≈{stat['mean']:.2} ±{stat['std']:.2}")
       output_parts.append(f" [≥{stat['nanmin']:.2}, ≤{stat['nanmax']:.2}]")
 
     if is_integer:
       output_parts.append(f" [≥{stat['min']:_d}, ≤{stat['max']:_d}]")
+    # pylint: enable=inconsistent-quotes
 
     def append_if_present(output_parts, *names):
       for name in names:


### PR DESCRIPTION
Turns on checking pyink formatting for test files.

Also disables a bad Python version for pyink.
Black and Pyink do not support python 3.12.5, but uvx automatically selects this version occasionally, which breaks autoformatting in VSCode.