### PR TITLE
Fix render_array to respect explicit axis ordering.

### DIFF
--- a/treescope/_internal/arrayviz_impl.py
+++ b/treescope/_internal/arrayviz_impl.py
@@ -351,16 +351,16 @@ def infer_rows_and_columns(
       row_size *= axis_size
 
   # The specific ordering of axes along the rows and the columns is somewhat
-  # arbitrary. Re-order each so that they have positional then named axes, and
-  # so that position axes are in reverse position order, and the explicitly
-  # mentioned named axes are before the unassigned ones.
+  # arbitrary. Re-order each so that explicitly requested axes are first, then
+  # unassigned positional axes in reverse position order, then unassigned named
+  # axes.
   def ax_sort_key(ax: AxisInfo):
-    if isinstance(ax, PositionalAxisInfo | NamedPositionalAxisInfo):
-      return (0, -ax.axis_logical_index)
-    elif ax in unassigned:
-      return (2,)
+    if ax not in unassigned:
+      return (0,)
+    elif isinstance(ax, PositionalAxisInfo | NamedPositionalAxisInfo):
+      return (1, -ax.axis_logical_index)
     else:
-      return (1,)
+      return (2,)
 
   return sorted(rows, key=ax_sort_key), sorted(columns, key=ax_sort_key)
 


### PR DESCRIPTION
`treescope.render_array` is documented as preserving the explicit ordering of rows and columns requested by the user, but this did not actually work as documented. This change adjusts the ordering inference logic to respect the requested order correctly.

Fixes #41.