### PR TITLE
Prevent summarizing JAX PRNG key dtypes.

### DIFF
--- a/tests/jax_support_test.py
+++ b/tests/jax_support_test.py
@@ -15,6 +15,7 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 from jax import numpy as jnp
+import jax
 import treescope.external.jax_support
 
 
@@ -29,6 +30,18 @@ class JaxSupportTest(parameterized.TestCase):
     self.assertEqual(
         treescope.external.jax_support.summarize_array_data(inp), expected
     )
+
+  def test_summarize_prng_key(self):
+    keys = jax.random.split(jax.random.key(0, impl="threefry2x32"), 10)
+    summarized = treescope.external.jax_support.summarize_array_data(keys)
+    self.assertEqual(summarized, "")
+
+    full_summary = (
+        treescope.external.jax_support.JAXArrayAdapter().get_array_summary(
+            keys, fast=False
+        )
+    )
+    self.assertEqual(full_summary, "jax.Array key<fry>(10,)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Numeric dtypes can be summaried by outputting summary statistics (e.g. min, max, avg, sparsity), but we do not produce any summary for extended dtypes like JAX PRNG key dtypes. However, the existing implementation still tries to convert the arrays to numpy for faster summarization even if the dtype cannot be summarized, which produced an error. This commit disables summarization fully for these dtypes so that they can be rendered as normal.

Fixes #52.