### PR TITLE
Improvements to output rendering for VSCode.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,6 +162,7 @@ myst_enable_extensions = [
 # nb_execution_mode can be overridden on a notebook level via .ipynb metadata
 nb_execution_mode = 'auto'
 nb_execution_allow_errors = False
+nb_execution_raise_on_error = True
 # nb_execution_excludepatterns = ['notebooks/*']
 
 # -- Options for katex ------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ docs = [
     "palettable==3.3.3",
     "pandas==2.2.2",
     "plotly==5.22.0",
-    "penzai~=0.2.0",
+    "penzai~=0.2.4",
     "sphinx_contributors",
     "sphinx-hoverxref",
     "torch==2.3.1",

--- a/treescope/_internal/html_encapsulation.py
+++ b/treescope/_internal/html_encapsulation.py
@@ -127,7 +127,7 @@ CONTAINER_TEMPLATE = """
 })();
 </script>
 <treescope-container class="{__REPLACE_ME_WITH_CONTAINER_ID_CLASS__}"
-></treescope-container>
+style="display:block"></treescope-container>
 <treescope-run-here><script type="application/octet-stream">
 // Find the target container based on its ID class. We use a class instead of
 // an HTML id because it's possible that the notebook display system will
@@ -263,7 +263,20 @@ const root = (
   .filter((elt) => !elt.dataset.stolen)
 )[0];
 root.dataset.stolen = 1;
+// Some notebook environments (in particular, VSCode's embedded notebook)
+// will hide outputs that are empty, but moving elements between different
+// positions can confuse it. To avoid this, we add and remove small amounts of
+// padding to trigger resize detection.
+// 1. Insert temporary element before the stolen element in the old cell.
+const temp = document.createElement("div");
+temp.style = "height: 1px; width: 1px;";
+root.parentNode.insertBefore(temp, root);
+// 2. Move the stolen element into this cell.
 this.parentNode.replaceChild(root, this);
+// 3. Remove the temporary element.
+temp.remove();
+// 4. Add padding to the stolen element, now that it is in this cell.
+root.style.paddingTop = "1px";
 </script></treescope-run-here>
 """
 

--- a/treescope/lowering.py
+++ b/treescope/lowering.py
@@ -299,6 +299,8 @@ def _render_to_html_as_root_streaming(
       background-color: white;
       color: black;
       width: fit-content;
+      min-width: 100%;
+      box-sizing: border-box;
       padding-left: 2ch;
       line-height: 1.5;
       contain: content;

--- a/uv.lock
+++ b/uv.lock
@@ -1962,7 +1962,7 @@ wheels = [
 
 [[package]]
 name = "penzai"
-version = "0.2.2"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -1972,9 +1972,9 @@ dependencies = [
     { name = "treescope" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/61/48ce2a1d8a16a4b778837981bed648cb9ea4aefb7b91bc6490b405a17b87/penzai-0.2.2.tar.gz", hash = "sha256:f08b1c7151ea07dfe80b99abc5c749942fb0da112ed2ba82d5588ec255f8e8be", size = 36596103 }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/4b/3cdbb6b95c152c33040e61703ff70bdf989f1942034c24a9db4f90574a90/penzai-0.2.4.tar.gz", hash = "sha256:790462f7b363bdcbb2fe2c6e0e8e4215208afd4d75be2c065bcbb4f3645dc058", size = 912213 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/89/c96aa7941afceddef928e0b3ffe99c2eb25b0012b164dc5234fc049dd3aa/penzai-0.2.2-py3-none-any.whl", hash = "sha256:387caf4a0af4067658528ae931648421b8fe2d62d0b32eb0c9254b2d95771e7e", size = 314479 },
+    { url = "https://files.pythonhosted.org/packages/d9/96/f2f695a4b4659d9540c25c08a61d1f9accc7938c94b7deaf79bba9efeb92/penzai-0.2.4-py3-none-any.whl", hash = "sha256:107b03be3e959bb1aeb0357cd1a7f30aab8264ef64b931157f2873118acdc85a", size = 317839 },
 ]
 
 [[package]]
@@ -3097,7 +3097,7 @@ requires-dist = [
     { name = "palettable", marker = "extra == 'docs'", specifier = "==3.3.3" },
     { name = "palettable", marker = "extra == 'notebook'" },
     { name = "pandas", marker = "extra == 'docs'", specifier = "==2.2.2" },
-    { name = "penzai", marker = "extra == 'docs'", specifier = "~=0.2.0" },
+    { name = "penzai", marker = "extra == 'docs'", specifier = "~=0.2.4" },
     { name = "plotly", marker = "extra == 'docs'", specifier = "==5.22.0" },
     { name = "pyink", marker = "extra == 'dev'", specifier = ">=24.3.0" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=2.6.0" },


### PR DESCRIPTION
VSCode's IPython notebook rendering works slightly differently than JupyterLab and Colab. This commit makes a few changes to improve the way Treescope works in this setting:

- Inserts and removes small amounts of padding, to trigger VSCode to re-evaluate whether "cell output" blocks should be hidden. Previously, VSCode would have false positive and false negatives about which blocks are empty due to Treescope's output-stealing behavior. Adding and removing padding forces VSCode to identify that the temporary output cell is now empty and the final output cell now contains content.
- Changes the treescope root element to have a white background that extends the full width of the output cell, which can improve appearance when using Treescope to render small values in a dark-mode theme (since Treescope outputs always appear with a white background and dark mode is not yet supported inside a rendering).

Also fixes some errors in building documentation.