### PR TITLE
Implement abbreviation system to avoid very-long-line outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,24 @@ Once you've rendered an object, try clicking on it and pressing the `r` key!
 This turns on "roundtrip mode", and adds qualified names to every type in the
 visualization, making it easier to identify what the types in your object are.
 
-For more information on how to use Treescope, check out the [Treescope documentation](https://treescope.readthedocs.io).
+> [!TIP]
+> If Treescope's outputs are too verbose, or if you are using a terminal that
+> wraps lines, you can configure Treescope to abbreviate collapsed objects at a
+> given depth using:
+>
+> ```python
+> treescope.basic_interactive_setup(
+>     autovisualize_arrays=True,
+>     abbreviation_threshold=1,  # or a different value
+> )
+> ```
+>
+> You can also configure the abbreviation threshold manually by overriding
+> `treescope.abbreviation_threshold` using the `.set_globally` or `.set_scoped`
+> methods.
+
+For more information on how to use Treescope, check out the
+[Treescope documentation](https://treescope.readthedocs.io).
 
 Looking for a neural network library with first-class support for Treescope's
 visualization features?

--- a/docs/api/treescope.rst
+++ b/docs/api/treescope.rst
@@ -108,6 +108,8 @@ configured globally using `context.ContextualValue.set_globally`.
   active_renderer
   default_magic_autovisualizer
   active_expansion_strategy
+  abbreviation_threshold
+  roundtrip_abbreviation_threshold
 
 
 Rendering to strings
@@ -134,4 +136,3 @@ Other utilities
   integer_digitbox
   render_array_sharding
   using_expansion_strategy
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,6 +92,20 @@ Once you've rendered an object, try clicking on it and pressing the ``r`` key!
 This turns on "roundtrip mode", and adds qualified names to every type in the
 visualization, making it easier to identify what the types in your object are.
 
+.. tip::
+   If Treescope's outputs are too verbose, or if you are using a terminal that
+   wraps lines, you can configure Treescope to abbreviate collapsed objects at a
+   given depth using ::
+
+      treescope.basic_interactive_setup(
+          autovisualize_arrays=True,
+          abbreviation_threshold=1,  # or a different value
+      )
+
+   You can also configure the abbreviation threshold manually by overriding
+   `treescope.abbreviation_threshold` using the ``.set_globally`` or
+   ``.set_scoped`` methods.
+
 Looking for a neural network library with first-class support for Treescope's
 visualization features?
 Try `Penzai <https://penzai.readthedocs.io/en/stable>`_!

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,10 @@
+"""Helper functions for tests."""
+
+from treescope import rendering_parts, lowering
+
+
+def ensure_text(text_or_part: str | rendering_parts.RenderableTreePart) -> str:
+  """Ensure that a part is a string, lowering it if necessary."""
+  if isinstance(text_or_part, str):
+    return text_or_part
+  return lowering.render_to_text_as_root(text_or_part)

--- a/tests/jax_support_test.py
+++ b/tests/jax_support_test.py
@@ -17,6 +17,7 @@ from absl.testing import parameterized
 from jax import numpy as jnp
 import jax
 import treescope.external.jax_support
+from . import helpers
 
 
 class JaxSupportTest(parameterized.TestCase):
@@ -36,7 +37,7 @@ class JaxSupportTest(parameterized.TestCase):
     summarized = treescope.external.jax_support.summarize_array_data(keys)
     self.assertEqual(summarized, "")
 
-    full_summary = (
+    full_summary = helpers.ensure_text(
         treescope.external.jax_support.JAXArrayAdapter().get_array_summary(
             keys, fast=False
         )

--- a/tests/ndarray_adapters_test.py
+++ b/tests/ndarray_adapters_test.py
@@ -26,6 +26,7 @@ import torch
 import treescope
 from treescope import ndarray_adapters
 from treescope import type_registries
+from . import helpers
 
 
 class NdarrayAdaptersTest(parameterized.TestCase):
@@ -142,8 +143,12 @@ class NdarrayAdaptersTest(parameterized.TestCase):
 
     for fast in (True, False):
       with self.subTest("summary_fast" if fast else "summary_slow"):
-        summary_info_np = np_adapter.get_array_summary(array_np, fast=True)
-        summary_info = cur_adapter.get_array_summary(array, fast=True)
+        summary_info_np = helpers.ensure_text(
+            np_adapter.get_array_summary(array_np, fast=True)
+        )
+        summary_info = helpers.ensure_text(
+            cur_adapter.get_array_summary(array, fast=True)
+        )
         self.assertEqual(
             summary_info_np.split(" ", 1)[1], summary_info.split(" ", 1)[1]
         )

--- a/tests/renderer_test.py
+++ b/tests/renderer_test.py
@@ -37,6 +37,7 @@ from treescope import lowering
 from treescope import rendering_parts
 from treescope.external import jax_support
 from tests.fixtures import treescope_examples_fixture as fixture_lib
+from . import helpers
 
 
 @dataclasses.dataclass
@@ -708,7 +709,9 @@ class TreescopeRendererTest(parameterized.TestCase):
     def go(s):
       nonlocal renderer, x
       adapter = jax_support.JAXArrayAdapter()
-      self.assertNotEmpty(adapter.get_array_summary(x, False))
+      self.assertNotEmpty(
+          helpers.ensure_text(adapter.get_array_summary(x, False))
+      )
       return jax.numpy.sum(s)
 
     go(jnp.arange(3))

--- a/tests/renderer_test.py
+++ b/tests/renderer_test.py
@@ -21,7 +21,7 @@ import functools
 import re
 import textwrap
 import types
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 import warnings
 
 from absl.testing import absltest
@@ -49,6 +49,11 @@ class CustomReprHTMLObject:
 
 
 class TreescopeRendererTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    treescope.abbreviation_threshold.set_globally(None)
+    treescope.roundtrip_abbreviation_threshold.set_globally(None)
 
   def test_renderer_interface(self):
     renderer = treescope.active_renderer.get()
@@ -591,6 +596,218 @@ class TreescopeRendererTest(parameterized.TestCase):
                 ),
               )"""),
       ),
+      # Abbreviated objects.
+      dict(
+          testcase_name="abbreviated_list",
+          target={"inner": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': [<10 elements...>]}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_tuple",
+          target={"inner": (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)},
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': (<10 elements...>)}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_set",
+          target={"inner": {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': {<10 elements...>}}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_list_of_single_string",
+          target={
+              "inner": ["a single element that is potentially pretty long"]
+          },
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': [<1 element...>]}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': ['a sin'<38 chars...>' long'],
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_dict",
+          target={
+              "inner": {
+                  "a": 1,
+                  "b": 2,
+                  "c": 3,
+                  "d": 4,
+                  "e": [1, 2, 3],
+              }
+          },
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': {<5 items...>}}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': [<3 elements...>]},
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_string",
+          target={"inner": "a single element that is potentially pretty long"},
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': 'a sin'<38 chars...>' long'}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': 'a single element that is potentially pretty long',
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_bytes",
+          target={"inner": b"a single element that is potentially pretty long"},
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': b'a sin'<38 chars...>b' long'}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': b'a single element that is potentially pretty long',
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_short_string",
+          target={"inner": "short"},
+          abbreviation_threshold=1,
+          expand_depth=1,
+          # too short to abbreviate
+          expected_collapsed="{'inner': 'short'}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': 'short',
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_simplenamespace",
+          target={
+              "inner": types.SimpleNamespace(a=1, b=2, c=3, d=4, e=[1, 2, 3])
+          },
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="{'inner': SimpleNamespace(<5 attributes...>)}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': SimpleNamespace(a=1, b=2, c=3, d=4, e=[<3 elements...>]),
+              }"""),
+          expected_roundtrip_collapsed=(
+              "{'inner': types.SimpleNamespace(<5 attributes...>)}"
+          ),
+          expected_roundtrip=textwrap.dedent("""\
+              {
+                'inner': types.SimpleNamespace(a=1, b=2, c=3, d=4, e=[<3 elements...>]),
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_simplenamespace_different_thresholds",
+          target={
+              "inner": types.SimpleNamespace(
+                  a=1, b=2, c=3, d=4, e=(1, 2, 3, 4, 5)
+              )
+          },
+          abbreviation_threshold=1,
+          roundtrip_abbreviation_threshold=2,
+          expand_depth=1,
+          expected_collapsed="{'inner': SimpleNamespace(<5 attributes...>)}",
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': SimpleNamespace(a=1, b=2, c=3, d=4, e=(<5 elements...>)),
+              }"""),
+          expected_roundtrip_collapsed=(
+              """{'inner': types.SimpleNamespace(a=1, b=2, c=3, d=4, e=(<5 elements...>))}"""
+          ),
+          expected_roundtrip=textwrap.dedent("""\
+              {
+                'inner': types.SimpleNamespace(a=1, b=2, c=3, d=4, e=(1, 2, 3, 4, 5)),
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_dataclass",
+          target={
+              "inner": fixture_lib.DataclassWithTwoChildren(
+                  foo=1, bar=[1, 2, 3, 4, 5]
+              )
+          },
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed=(
+              "{'inner': DataclassWithTwoChildren(<2 fields...>)}"
+          ),
+          expected_expanded=textwrap.dedent("""\
+              {
+                'inner': DataclassWithTwoChildren(foo=1, bar=[<5 elements...>]),
+              }"""),
+      ),
+      dict(
+          testcase_name="abbreviated_ndarray",
+          target=[np.arange(3 * 7).reshape((3, 7))],
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="[<np int64(3, 7)>]",
+          expected_expanded=textwrap.dedent("""\
+              [
+                <np.ndarray int64(3, 7) [≥0, ≤20] zero:1 nonzero:20>,
+              ]"""),
+      ),
+      dict(
+          testcase_name="abbreviated_jax_array",
+          target_builder=lambda: [jnp.arange(3 * 7).reshape((3, 7))],
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="[<jax int32(3, 7)>]",
+          expected_expanded=textwrap.dedent("""\
+              [
+                <jax.Array int32(3, 7) [≥0, ≤20] zero:1 nonzero:20>,
+              ]"""),
+      ),
+      dict(
+          testcase_name="abbreviated_pytorch_tensor",
+          target_builder=lambda: [
+              torch.tensor(np.arange(3 * 7).reshape((3, 7)))
+          ],
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="[<torch int64(3, 7)>]",
+          expected_expanded=textwrap.dedent("""\
+              [
+                <torch.Tensor int64(3, 7) [≥0, ≤20] zero:1 nonzero:20>,
+              ]"""),
+      ),
+      dict(
+          testcase_name="abbreviated_pytorch_param",
+          target_builder=lambda: [
+              torch.nn.Parameter(
+                  torch.tensor(
+                      np.arange(3 * 7, dtype=np.float32).reshape((3, 7))
+                  )
+              )
+          ],
+          abbreviation_threshold=1,
+          expand_depth=1,
+          expected_collapsed="[<Param float32(3, 7)>]",
+          expected_expanded=textwrap.dedent("""\
+              [
+                <torch.nn.Parameter float32(3, 7) ≈1e+01 ±3.7e+01 [≥0.0, ≤2e+01] zero:1 nonzero:20>,
+              ]"""),
+      ),
   )
   def test_object_rendering(
       self,
@@ -602,6 +819,8 @@ class TreescopeRendererTest(parameterized.TestCase):
       expected_roundtrip: str | None = None,
       expected_roundtrip_collapsed: str | None = None,
       expand_depth: int = 1,
+      abbreviation_threshold: int | None = None,
+      roundtrip_abbreviation_threshold: int | None | Literal["same"] = "same",
       ignore_exceptions: bool = False,
   ):
     if target_builder is not None:
@@ -621,42 +840,50 @@ class TreescopeRendererTest(parameterized.TestCase):
           )
       )
 
-    # Collapse all foldables.
-    layout_algorithms.expand_to_depth(rendering, 0)
+    if roundtrip_abbreviation_threshold == "same":
+      roundtrip_abbreviation_threshold = abbreviation_threshold
+    with (
+        treescope.abbreviation_threshold.set_scoped(abbreviation_threshold),
+        treescope.roundtrip_abbreviation_threshold.set_scoped(
+            roundtrip_abbreviation_threshold
+        ),
+    ):
+      # Collapse all foldables.
+      layout_algorithms.expand_to_depth(rendering, 0)
 
-    if expected_collapsed is not None:
-      with self.subTest("collapsed"):
-        self.assertEqual(
-            lowering.render_to_text_as_root(rendering),
-            expected_collapsed,
-        )
+      if expected_collapsed is not None:
+        with self.subTest("collapsed"):
+          self.assertEqual(
+              lowering.render_to_text_as_root(rendering),
+              expected_collapsed,
+          )
 
-    if expected_roundtrip_collapsed is not None:
-      with self.subTest("roundtrip_collapsed"):
-        self.assertEqual(
-            lowering.render_to_text_as_root(rendering, roundtrip=True),
-            expected_roundtrip_collapsed,
-        )
+      if expected_roundtrip_collapsed is not None:
+        with self.subTest("roundtrip_collapsed"):
+          self.assertEqual(
+              lowering.render_to_text_as_root(rendering, roundtrip=True),
+              expected_roundtrip_collapsed,
+          )
 
-    layout_algorithms.expand_to_depth(rendering, expand_depth)
+      layout_algorithms.expand_to_depth(rendering, expand_depth)
 
-    if expected_expanded is not None:
-      with self.subTest("expanded"):
-        self.assertEqual(
-            lowering.render_to_text_as_root(rendering),
-            expected_expanded,
-        )
+      if expected_expanded is not None:
+        with self.subTest("expanded"):
+          self.assertEqual(
+              lowering.render_to_text_as_root(rendering),
+              expected_expanded,
+          )
 
-    if expected_roundtrip is not None:
-      with self.subTest("roundtrip"):
-        self.assertEqual(
-            lowering.render_to_text_as_root(rendering, roundtrip=True),
-            expected_roundtrip,
-        )
+      if expected_roundtrip is not None:
+        with self.subTest("roundtrip"):
+          self.assertEqual(
+              lowering.render_to_text_as_root(rendering, roundtrip=True),
+              expected_roundtrip,
+          )
 
-    # Render to HTML; make sure it doesn't raise any errors.
-    with self.subTest("html_no_errors"):
-      _ = lowering.render_to_html_as_root(rendering)
+      # Render to HTML; make sure it doesn't raise any errors.
+      with self.subTest("html_no_errors"):
+        _ = lowering.render_to_html_as_root(rendering)
 
   def test_closure_rendering(self):
     def outer_fn(x):
@@ -758,6 +985,11 @@ class TreescopeRendererTest(parameterized.TestCase):
         lowering.render_to_text_as_root(rendering),
         "[<custom repr for UnknownObjectWithOneLineRepr>]",
     )
+    with treescope.abbreviation_threshold.set_scoped(1):
+      self.assertEqual(
+          lowering.render_to_text_as_root(rendering),
+          "[<UnknownObjectWithOneLineRepr...>]",
+      )
     layout_algorithms.expand_to_depth(rendering, 2)
     self.assertEqual(
         lowering.render_to_text_as_root(rendering),
@@ -851,6 +1083,11 @@ class TreescopeRendererTest(parameterized.TestCase):
         lowering.render_to_text_as_root(rendering),
         "[<custom repr↩  for↩  UnknownObjectWithMultiLineRepr↩>]",
     )
+    with treescope.abbreviation_threshold.set_scoped(1):
+      self.assertEqual(
+          lowering.render_to_text_as_root(rendering),
+          "[<UnknownObjectWithMultiLineRepr...>]",
+      )
     layout_algorithms.expand_to_depth(rendering, 2)
     self.assertEqual(
         lowering.render_to_text_as_root(rendering),
@@ -874,6 +1111,11 @@ class TreescopeRendererTest(parameterized.TestCase):
         lowering.render_to_text_as_root(rendering),
         f"[{object.__repr__(target[0])}]",
     )
+    with treescope.abbreviation_threshold.set_scoped(1):
+      self.assertEqual(
+          lowering.render_to_text_as_root(rendering),
+          "[<UnknownObjectWithBadMultiLineRepr...>]",
+      )
     layout_algorithms.expand_to_depth(rendering, 2)
     self.assertEqual(
         lowering.render_to_text_as_root(rendering),

--- a/treescope/__init__.py
+++ b/treescope/__init__.py
@@ -49,6 +49,10 @@ from . import rendering_parts
 from . import repr_lib
 from . import type_registries
 
+from ._internal.api.abbreviation import (
+    abbreviation_threshold,
+    roundtrip_abbreviation_threshold,
+)
 from ._internal.api.array_autovisualizer import (
     ArrayAutovisualizer,
 )
@@ -150,6 +154,33 @@ default_magic_autovisualizer: context.ContextualValue[Autovisualizer] = (
 
 This can be overridden interactively to customize the autovisualizer
 used by ``%%autovisualize``.
+"""
+
+abbreviation_threshold: context.ContextualValue[int | None] = (
+    abbreviation_threshold
+)
+"""Depth threshold for abbreviating large outputs in normal mode.
+
+This value sets the depth at which values should be abbreviated (replaced by
+... markers) when their parents are collapsed. Threshold 1 means that children
+of a collapsed node should be abbreviated. Threshold 2 means that grandchildren
+of a collapsed node should be abbreviated. Threshold None means that no
+abbreviation should be performed.
+"""
+
+roundtrip_abbreviation_threshold: context.ContextualValue[int | None] = (
+    roundtrip_abbreviation_threshold
+)
+"""Depth threshold for abbreviating large outputs in roundtrip mode.
+
+This value sets the depth at which values should be abbreviated (replaced by
+... markers) when their parents are collapsed. Threshold 1 means that children
+of a collapsed node should be abbreviated. Threshold 2 means that grandchildren
+of a collapsed node should be abbreviated. Threshold None means that no
+abbreviation should be performed.
+
+Note that if abbreviation is enabled in roundtrip mode, outputs may not be
+fully roundtrippable due to the abbreviated children.
 """
 
 # Package version.

--- a/treescope/_internal/api/abbreviation.py
+++ b/treescope/_internal/api/abbreviation.py
@@ -1,0 +1,19 @@
+"""Configurable settings for abbreviation."""
+
+from treescope import context
+
+
+abbreviation_threshold: context.ContextualValue[int | None] = (
+    context.ContextualValue(
+        module=__name__,
+        qualname="abbreviation_threshold",
+        initial_value=None,
+    )
+)
+roundtrip_abbreviation_threshold: context.ContextualValue[int | None] = (
+    context.ContextualValue(
+        module=__name__,
+        qualname="roundtrip_abbreviation_threshold",
+        initial_value=None,
+    )
+)

--- a/treescope/_internal/api/array_autovisualizer.py
+++ b/treescope/_internal/api/array_autovisualizer.py
@@ -93,7 +93,7 @@ class ArrayAutovisualizer:
       array: ArrayInRegistry,
       adapter: ndarray_adapters.NDArrayAdapter,
       path: str | None,
-      label: str,
+      label: rendering_parts.RenderableTreePart,
       expand_state: rendering_parts.ExpandState,
   ) -> rendering_parts.RenderableTreePart:
     """Helper to visualize an array."""
@@ -231,7 +231,7 @@ class ArrayAutovisualizer:
     else:
       last_line = rendering_parts.text(">")
     custom_rendering = rendering_parts.build_custom_foldable_tree_node(
-        label=rendering_parts.abbreviation_color(rendering_parts.text(label)),
+        label=rendering_parts.abbreviation_color(label),
         contents=rendering_parts.siblings(
             rendering_parts.fold_condition(
                 expanded=rendering_parts.indented_children(outputs)
@@ -269,7 +269,9 @@ class ArrayAutovisualizer:
       def _placeholder() -> rendering_parts.RenderableTreePart:
         summary = adapter.get_array_summary(value, fast=True)
         return rendering_parts.deferred_placeholder_style(
-            rendering_parts.text(f"<{summary}>")
+            rendering_parts.siblings(
+                rendering_parts.text("<"), summary, rendering_parts.text(">")
+            )
         )
 
       def _thunk(
@@ -279,7 +281,8 @@ class ArrayAutovisualizer:
         if expand_state is None:
           expand_state = rendering_parts.ExpandState.WEAKLY_EXPANDED
         summary = adapter.get_array_summary(value, fast=False)
-        label = f"<{summary}"
+        label = rendering_parts.siblings(rendering_parts.text("<"), summary)
+
         return self._autovisualize_array(
             value, adapter, path, label, expand_state
         )

--- a/treescope/_internal/api/ipython_integration.py
+++ b/treescope/_internal/api/ipython_integration.py
@@ -22,6 +22,7 @@ from treescope import figures
 from treescope import lowering
 from treescope import rendering_parts
 from treescope._internal import object_inspection
+from treescope._internal.api import abbreviation as abbreviation_lib
 from treescope._internal.api import array_autovisualizer
 from treescope._internal.api import autovisualize as autovisualize_lib
 from treescope._internal.api import default_renderer
@@ -510,7 +511,10 @@ def register_context_manager_magic():
   IPython.get_ipython().register_magics(ContextManagerMagic)
 
 
-def basic_interactive_setup(autovisualize_arrays: bool = True):
+def basic_interactive_setup(
+    autovisualize_arrays: bool = True,
+    abbreviation_threshold: int | None = None,
+):
   """Sets up IPython for interactive use with Treescope.
 
   This is a helper function that runs various setup steps:
@@ -521,9 +525,13 @@ def basic_interactive_setup(autovisualize_arrays: bool = True):
     * Registers the `%%with` magic.
     * If `autovisualize_arrays` is True, configures Treescope to automatically
       visualize arrays.
+    * If `abbreviation_threshold` is not None, configures Treescope to
+      abbreviate collapsed objects at the given depth.
 
   Args:
     autovisualize_arrays: Whether to automatically visualize arrays.
+    abbreviation_threshold: If not None, configures Treescope to abbreviate
+      collapsed objects at the given depth (recommended to set to 1 or 2).
   """
   register_as_default()
   register_autovisualize_magic()
@@ -533,3 +541,6 @@ def basic_interactive_setup(autovisualize_arrays: bool = True):
     autovisualize_lib.active_autovisualizer.set_globally(
         array_autovisualizer.ArrayAutovisualizer()
     )
+
+  if abbreviation_threshold is not None:
+    abbreviation_lib.abbreviation_threshold.set_globally(abbreviation_threshold)

--- a/treescope/_internal/handlers/generic_repr_handler.py
+++ b/treescope/_internal/handlers/generic_repr_handler.py
@@ -55,7 +55,7 @@ def handle_anything_with_repr(
           for line in lines[:-1]
       ]
       lines_with_markers.append(rendering_parts.text(lines[-1]))
-      return rendering_parts.siblings_with_annotations(
+      result = rendering_parts.siblings_with_annotations(
           rendering_parts.build_custom_foldable_tree_node(
               contents=rendering_parts.abbreviation_color(
                   rendering_parts.siblings(*lines_with_markers)
@@ -70,7 +70,7 @@ def handle_anything_with_repr(
       )
     else:
       # Use basic repr as the summary.
-      return rendering_parts.build_custom_foldable_tree_node(
+      result = rendering_parts.build_custom_foldable_tree_node(
           label=rendering_parts.abbreviation_color(
               rendering_parts.comment_color_when_expanded(
                   rendering_parts.siblings(
@@ -92,7 +92,7 @@ def handle_anything_with_repr(
       )
   elif node_repr == basic_repr:
     # Just use the basic repr as the summary, since we don't have anything else.
-    return rendering_parts.build_one_line_tree_node(
+    result = rendering_parts.build_one_line_tree_node(
         line=rendering_parts.abbreviation_color(
             rendering_parts.text(node_repr)
         ),
@@ -102,7 +102,7 @@ def handle_anything_with_repr(
     # Use the custom repr as a one-line summary, but float the basic repr to
     # the right to tell the user what the type is in case the custom repr
     # doesn't include that info.
-    return rendering_parts.siblings_with_annotations(
+    result = rendering_parts.siblings_with_annotations(
         rendering_parts.build_one_line_tree_node(
             line=rendering_parts.abbreviation_color(
                 rendering_parts.text(node_repr)
@@ -115,3 +115,14 @@ def handle_anything_with_repr(
             )
         ],
     )
+
+  # Possibly apply abbreviation.
+  if len(node_repr) > 20:
+    result = rendering_parts.abbreviatable_with_annotations(
+        result,
+        rendering_parts.abbreviation_color(
+            rendering_parts.text(f"<{type(node).__name__}...>")
+        ),
+    )
+
+  return result

--- a/treescope/_internal/parts/foldable_impl.py
+++ b/treescope/_internal/parts/foldable_impl.py
@@ -501,6 +501,12 @@ class HasAbbreviation(basic_parts.DeferringToChild):
         | self.abbreviation.html_setup_parts(setup_context)
     )
 
+  def _compute_layout_marks_in_this_part(self) -> frozenset[Any]:
+    return (
+        self.child.layout_marks_in_this_part
+        | self.abbreviation.layout_marks_in_this_part
+    )
+
   def render_to_html(
       self,
       stream: io.TextIOBase,

--- a/treescope/_internal/parts/foldable_impl.py
+++ b/treescope/_internal/parts/foldable_impl.py
@@ -15,7 +15,7 @@
 """Low-level implementation details of the foldable system.
 
 This module contains low-level wrappers that handle folding and unfolding,
-path copy button rendering, and deferred rendering.
+path copy button rendering, deferred rendering, and abbreviation.
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ from typing import Any, Callable, Sequence
 
 from treescope._internal import html_escaping
 from treescope._internal.parts import basic_parts
+from treescope._internal.parts import common_styles
 from treescope._internal.parts import part_interface
 
 
@@ -37,12 +38,16 @@ ExpandState = part_interface.ExpandState
 FoldableTreeNode = part_interface.FoldableTreeNode
 
 
-SETUP_CONTEXT = HtmlContextForSetup(
-    collapsed_selector=(
-        ".foldable_node:has(>label>.foldable_node_toggle:not(:checked))"
-    ),
-    roundtrip_selector=".treescope_root.roundtrip_mode",
+COLLAPSED_SELECTOR = (
+    ".foldable_node:has(>label>.foldable_node_toggle:not(:checked))"
 )
+ROUNDTRIP_SELECTOR = ".treescope_root.roundtrip_mode"
+NOT_ROUNDTRIP_SELECTOR = ".treescope_root:not(.roundtrip_mode)"
+
+ABBREVIATION_LEVEL_KEY = "abbreviation_level"
+ABBREVIATION_THRESHOLD_KEY = "abbreviation_threshold"
+ABBREVIATION_LEVEL_CLASS = "abbr_lvl"
+
 
 ################################################################################
 # Foldable node implementation
@@ -84,10 +89,10 @@ class FoldableTreeNodeImpl(FoldableTreeNode):
   def html_setup_parts(
       self, setup_context: HtmlContextForSetup
   ) -> set[CSSStyleRule | JavaScriptDefn]:
-    if setup_context.collapsed_selector != SETUP_CONTEXT.collapsed_selector:
+    if setup_context.collapsed_selector != COLLAPSED_SELECTOR:
       raise ValueError(
           "FoldableTreeNodeImpl only works properly when the tree is"
-          " configured using SETUP_CONTEXT.collapsed_selector"
+          " configured using foldable_impl.COLLAPSED_SELECTOR"
       )
     # These CSS rules ensure that:
     # - Fold markers appear relative to the "foldable_node" HTML element
@@ -461,3 +466,205 @@ def fake_placeholder_foldable(
       ),
       expand_state=ExpandState.WEAKLY_EXPANDED,
   )
+
+
+################################################################################
+# Abbreviation
+################################################################################
+
+
+@dataclasses.dataclass
+class HasAbbreviation(basic_parts.DeferringToChild):
+  """A part with an abbreviation."""
+
+  child: RenderableTreePart
+  abbreviation: RenderableTreePart
+
+  def html_setup_parts(
+      self, setup_context: HtmlContextForSetup
+  ) -> set[CSSStyleRule | JavaScriptDefn]:
+    # Show or collapse based on the abbreviation selector.
+    rule = html_escaping.without_repeated_whitespace(f"""
+        .when_abbr {{
+            display: none;
+        }}
+        {setup_context.abbreviate_selector} .when_abbr {{
+            display: inline;
+        }}
+        {setup_context.abbreviate_selector} .not_abbr {{
+            display: none;
+        }}
+        """)
+    return (
+        {CSSStyleRule(rule)}
+        | self.child.html_setup_parts(setup_context)
+        | self.abbreviation.html_setup_parts(setup_context)
+    )
+
+  def render_to_html(
+      self,
+      stream: io.TextIOBase,
+      *,
+      at_beginning_of_line: bool = False,
+      render_context: dict[Any, Any],
+  ):
+    stream.write("<span class='not_abbr'>")
+    self.child.render_to_html(
+        stream,
+        at_beginning_of_line=at_beginning_of_line,
+        render_context=render_context,
+    )
+    stream.write("</span>")
+    stream.write("<span class='when_abbr'>")
+    self.abbreviation.render_to_html(
+        stream,
+        at_beginning_of_line=at_beginning_of_line,
+        render_context=render_context,
+    )
+    stream.write("</span>")
+
+  def render_to_text(
+      self,
+      stream: io.TextIOBase,
+      *,
+      expanded_parent: bool,
+      indent: int,
+      roundtrip_mode: bool,
+      render_context: dict[Any, Any],
+  ):
+    level = render_context.get(ABBREVIATION_LEVEL_KEY, 0)
+    threshold = render_context.get(ABBREVIATION_THRESHOLD_KEY, None)
+    if threshold is not None and level >= threshold:
+      self.abbreviation.render_to_text(
+          stream,
+          expanded_parent=expanded_parent,
+          indent=indent,
+          roundtrip_mode=roundtrip_mode,
+          render_context=render_context,
+      )
+    else:
+      self.child.render_to_text(
+          stream,
+          expanded_parent=expanded_parent,
+          indent=indent,
+          roundtrip_mode=roundtrip_mode,
+          render_context=render_context,
+      )
+
+
+@dataclasses.dataclass
+class AbbreviationLevel(basic_parts.DeferringToChild):
+  """Marks an abbreviation level, indicating that children may be abbreviated.
+
+  Abbreviation levels are only active when their parent is collapsed. Once we
+  pass a collapsed parent and the threshold number of further abbreviation
+  levels, children with abbreviations will be abbreviated.
+  """
+
+  child: RenderableTreePart
+
+  def render_to_html(
+      self,
+      stream: io.TextIOBase,
+      *,
+      at_beginning_of_line: bool = False,
+      render_context: dict[Any, Any],
+  ):
+    stream.write(f"<span class='{ABBREVIATION_LEVEL_CLASS}'>")
+    self.child.render_to_html(
+        stream,
+        at_beginning_of_line=at_beginning_of_line,
+        render_context=render_context,
+    )
+    stream.write("</span>")
+
+  def render_to_text(
+      self,
+      stream: io.TextIOBase,
+      *,
+      expanded_parent: bool,
+      indent: int,
+      roundtrip_mode: bool,
+      render_context: dict[Any, Any],
+  ):
+    if expanded_parent:
+      new_render_context = render_context
+    else:
+      # We need to increment the abbreviation level.
+      old_level = render_context.get(ABBREVIATION_LEVEL_KEY, 0)
+      new_render_context = {
+          **render_context,
+          ABBREVIATION_LEVEL_KEY: old_level + 1,
+      }
+
+    self.child.render_to_text(
+        stream,
+        expanded_parent=expanded_parent,
+        indent=indent,
+        roundtrip_mode=roundtrip_mode,
+        render_context=new_render_context,
+    )
+
+
+def abbreviatable(
+    child: RenderableTreePart, abbreviation: RenderableTreePart | None = None
+) -> RenderableTreePart:
+  """Marks an object as being able to be abbreviated.
+
+  Args:
+    object: The object to mark as abbreviatable. This will be replaced by the
+        fallback if the object is past the current abbreviation depth.
+    abbreviation: The fallback to use if the object is abbreviated.
+  """
+  if abbreviation is None:
+    abbreviation = basic_parts.siblings(
+        common_styles.comment_color(basic_parts.text("<")),
+        common_styles.abbreviation_color(basic_parts.text("...")),
+        common_styles.comment_color(basic_parts.text(">")),
+    )
+  return HasAbbreviation(child, abbreviation)
+
+
+def abbreviatable_with_annotations(
+    child: part_interface.RenderableAndLineAnnotations,
+    abbreviation: RenderableTreePart | None = None,
+) -> part_interface.RenderableAndLineAnnotations:
+  """Marks an object with annotations as being able to be abbreviated.
+
+  Args:
+    object: The object (with annotations) to mark as abbreviatable. This will
+        be replaced by the fallback if the object is past the current
+        abbreviation depth.
+    abbreviation: The fallback to use if the object is abbreviated.
+  """
+  return part_interface.RenderableAndLineAnnotations(
+      HasAbbreviation(child.renderable, abbreviation), child.annotations
+  )
+
+
+def abbreviation_level(child: RenderableTreePart) -> RenderableTreePart:
+  """Marks an abbreviation level, indicating children may be abbreviated."""
+  return AbbreviationLevel(child)
+
+
+def make_abbreviate_selector(
+    threshold: int | None, roundtrip_threshold: int | None
+) -> str:
+  """Builds a CSS selector that matches nodes that should be abbreviated.
+
+  Args:
+    threshold: The threshold for normal mode.
+    roundtrip_threshold: The threshold for roundtrip mode.
+
+  Returns:
+    A CSS selector that matches an ancestor of any node that should be
+    abbreviated.
+  """
+  options = []
+  if threshold is not None:
+    levels = f" .{ABBREVIATION_LEVEL_CLASS}" * threshold
+    options.append(f"{NOT_ROUNDTRIP_SELECTOR} {COLLAPSED_SELECTOR}{levels}")
+  if roundtrip_threshold is not None:
+    levels = f" .{ABBREVIATION_LEVEL_CLASS}" * roundtrip_threshold
+    options.append(f"{ROUNDTRIP_SELECTOR} {COLLAPSED_SELECTOR}{levels}")
+  return ":is(" + ", ".join(options) + ")"

--- a/treescope/_internal/parts/part_interface.py
+++ b/treescope/_internal/parts/part_interface.py
@@ -69,10 +69,14 @@ class HtmlContextForSetup:
       this as a prefix in the CSS selector.
     roundtrip_selector: A CSS selector that will match an ancestor of this node
       whenever rendering in roundtrip mode.
+    abbreviate_selector: A CSS selector that will match an ancestor of this
+      node whenever we are requesting that abbreviation should be applied to
+      this node (or its children).
   """
 
   collapsed_selector: str
   roundtrip_selector: str
+  abbreviate_selector: str
 
 
 ################################################################################

--- a/treescope/external/torch_support.py
+++ b/treescope/external/torch_support.py
@@ -174,16 +174,27 @@ class TorchTensorAdapter(ndarray_adapters.NDArrayAdapter[torch.Tensor]):
     )
     return array_dest, mask_dest
 
-  def get_array_summary(self, array: torch.Tensor, fast: bool) -> str:
+  def get_array_summary(
+      self, array: torch.Tensor, fast: bool
+  ) -> rendering_parts.RenderableTreePart:
     assert torch is not None, "PyTorch is not available."
     ty = type(array)
     array = array.detach()
     typename = f"{ty.__module__}.{ty.__name__}"
-    if typename == "torch.nn.parameter.Parameter":
+    abbrv = f"{ty.__name__}"
+    if typename == "torch.Tensor":
+      abbrv = "torch"
+    elif typename == "torch.nn.parameter.Parameter":
       typename = "torch.nn.Parameter"
-    output_parts = [f"{typename} "]
+      abbrv = "Param"
+    always_show_parts = [
+        rendering_parts.abbreviatable(
+            rendering_parts.text(f"{typename} "),
+            rendering_parts.text(f"{abbrv} "),
+        )
+    ]
 
-    output_parts.append(repr(array.dtype).removeprefix("torch."))
+    always_show_parts.append(repr(array.dtype).removeprefix("torch."))
     name_parts = []
     for size, name in zip(array.shape, array.names):
       if name:
@@ -191,9 +202,11 @@ class TorchTensorAdapter(ndarray_adapters.NDArrayAdapter[torch.Tensor]):
       else:
         name_parts.append(f"{size}")
     if len(name_parts) == 1:
-      output_parts.append("(" + name_parts[0] + ",)")
+      always_show_parts.append("(" + name_parts[0] + ",)")
     else:
-      output_parts.append("(" + ", ".join(name_parts) + ")")
+      always_show_parts.append("(" + ", ".join(name_parts) + ")")
+
+    summary_parts = []
 
     # Drop axis names.
     if any(name is not None for name in array.names):
@@ -214,48 +227,54 @@ class TorchTensorAdapter(ndarray_adapters.NDArrayAdapter[torch.Tensor]):
         std = torch.nanmean(torch.square(inf_to_nan - mean))
 
         if any_finite:
-          output_parts.append(f" ≈{float(mean):.2} ±{float(std):.2}")
+          summary_parts.append(f" ≈{float(mean):.2} ±{float(std):.2}")
           nanmin = torch.amin(torch.where(isfinite, array, torch.inf))
           nanmax = torch.amax(torch.where(isfinite, array, -torch.inf))
-          output_parts.append(f" [≥{float(nanmin):.2}, ≤{float(nanmax):.2}]")
+          summary_parts.append(f" [≥{float(nanmin):.2}, ≤{float(nanmax):.2}]")
 
       if is_integer:
-        output_parts.append(
+        summary_parts.append(
             f" [≥{torch.amin(array):_d}, ≤{torch.amax(array):_d}]"
         )
 
       if is_floating or is_integer:
         ct_zero = torch.count_nonzero(array == 0)
         if ct_zero:
-          output_parts.append(f" zero:{ct_zero:_d}")
+          summary_parts.append(f" zero:{ct_zero:_d}")
 
         ct_nonzero = torch.count_nonzero(array)
         if ct_nonzero:
-          output_parts.append(f" nonzero:{ct_nonzero:_d}")
+          summary_parts.append(f" nonzero:{ct_nonzero:_d}")
 
       if is_floating:
         ct_nan = torch.count_nonzero(torch.isnan(array))
         if ct_nan:
-          output_parts.append(f" nan:{ct_nan:_d}")
+          summary_parts.append(f" nan:{ct_nan:_d}")
 
         ct_inf = torch.count_nonzero(array == torch.inf)
         if ct_inf:
-          output_parts.append(f" inf:{ct_inf:_d}")
+          summary_parts.append(f" inf:{ct_inf:_d}")
 
         ct_neginf = torch.count_nonzero(array == -torch.inf)
         if ct_neginf:
-          output_parts.append(f" -inf:{ct_neginf:_d}")
+          summary_parts.append(f" -inf:{ct_neginf:_d}")
 
       if is_bool:
         ct_true = torch.count_nonzero(array)
         if ct_true:
-          output_parts.append(f" true:{ct_true:_d}")
+          summary_parts.append(f" true:{ct_true:_d}")
 
         ct_false = torch.count_nonzero(torch.logical_not(array))
         if ct_false:
-          output_parts.append(f" false:{ct_false:_d}")
+          summary_parts.append(f" false:{ct_false:_d}")
 
-    return "".join(output_parts)
+    return rendering_parts.siblings(
+        *always_show_parts,
+        rendering_parts.abbreviatable(
+            rendering_parts.siblings(*summary_parts),
+            rendering_parts.empty_part(),
+        ),
+    )
 
   def get_sharding_info_for_array_data(
       self, array: torch.Tensor
@@ -300,7 +319,7 @@ def render_torch_tensors(
 
   def _placeholder() -> rendering_parts.RenderableTreePart:
     return rendering_parts.deferred_placeholder_style(
-        rendering_parts.text(adapter.get_array_summary(node, fast=True))
+        adapter.get_array_summary(node, fast=True)
     )
 
   def _thunk(placeholder_expand_state: rendering_parts.ExpandState | None):
@@ -544,6 +563,7 @@ def render_torch_modules(
       background_color=background_color,
       background_pattern=background_pattern,
       expand_state=expand_state,
+      child_type_single_and_plural=("child", "children"),
   )
 
 

--- a/treescope/ndarray_adapters.py
+++ b/treescope/ndarray_adapters.py
@@ -27,6 +27,8 @@ from typing import Any, Generic, TypeVar
 
 import numpy as np
 
+from treescope import rendering_parts
+
 T = TypeVar("T")
 
 
@@ -199,7 +201,9 @@ class NDArrayAdapter(abc.ABC, Generic[T]):
     )
 
   @abc.abstractmethod
-  def get_array_summary(self, array: T, fast: bool) -> str:
+  def get_array_summary(
+      self, array: T, fast: bool
+  ) -> str | rendering_parts.RenderableTreePart:
     """Summarizes the contents of the given array.
 
     The summary returned by this method will be used as a one-line summary of
@@ -219,7 +223,8 @@ class NDArrayAdapter(abc.ABC, Generic[T]):
     Returns:
       A summary of the given array's contents. The summary should be a single
       line of text. It will be wrapped between angle brackets (< and >) when
-      rendered.
+      rendered. It may either be a string or a custom part (useful if the
+      summary should be abbreviated).
     """
     raise NotImplementedError("Subclasses must override `get_array_summary`.")
 

--- a/treescope/rendering_parts.py
+++ b/treescope/rendering_parts.py
@@ -67,6 +67,11 @@ from treescope._internal.parts.custom_dataclass_util import (
 from treescope._internal.parts.embedded_iframe import (
     embedded_iframe,
 )
+from treescope._internal.parts.foldable_impl import (
+    abbreviatable,
+    abbreviation_level,
+    abbreviatable_with_annotations,
+)
 from treescope._internal.parts.part_interface import (
     RenderableTreePart,
     RenderableAndLineAnnotations,
@@ -77,6 +82,9 @@ from treescope._internal.parts.part_interface import (
 
 
 __all__ = [
+    "abbreviatable",
+    "abbreviation_level",
+    "abbreviatable_with_annotations",
     "build_full_line_with_annotations",
     "empty_part",
     "floating_annotation_with_separate_focus",

--- a/treescope/repr_lib.py
+++ b/treescope/repr_lib.py
@@ -259,6 +259,7 @@ def render_dictionary_wrapper(
       suffix=closing_suffix,
       path=path,
       background_color=color,
+      child_type_single_and_plural=("item", "items"),
   )
 
 


### PR DESCRIPTION
Based on the idea from #53.

The abbreviation system has these main components:
- Abbreviation levels mark layers at which we should increment a counter, for "levels of depth" into an object. Usually each foldable tree node should increase the level of depth.
- Abbreviatable parts indicate parts of an output that should change if the abbreviation level is too high.
- The abbreviation threshold (one for regular and one for roundtrip) specifies the number of abbreviation levels *past* the first collaped tree node where abbreviation should apply.

Configurable as follows:

```python
# as part of the basic setup
treescope.basic_interactive_setup(
    autovisualize_arrays=True,
    abbreviation_threshold=1,
)

# set globally
treescope.abbreviation_threshold.set_globally(1)

# override in a context
with treescope.abbreviation_threshold.set_scoped(1):
  print(treescope.render_to_text(nested))
```

Produces outputs like this in HTML mode:

<img width="880" alt="image" src="https://github.com/user-attachments/assets/ace123f6-1365-45a9-8da2-a3f8c108e096" />

or like this in text mode:

```python
{
  'x0': {
    'foo': <np.ndarray float64(100, 100) ≈-0.0084 ±0.99 [≥-3.6, ≤3.8] nonzero:10_000>,
    'bar': {'x': 1111, 'y': 2222, 'z': 3333, 'c': Config(<6 fields...>)},
    'baz': [3, 3, 3, 3, 3, 3, 3],
  },
  'x1': {
    'foo': <np.ndarray float64(100, 100) ≈-0.02 ±0.99 [≥-4.2, ≤3.6] nonzero:10_000>,
    'bar': {'x': 1111, 'y': 2222, 'z': 3333, 'c': Config(<6 fields...>)},
    'baz': [3, 3, 3, 3, 3, 3, 3],
  },
  'x2': {
    'foo': <np.ndarray float64(100, 100) ≈0.0071 ±1.0 [≥-3.6, ≤3.7] nonzero:10_000>,
    'bar': {'x': 1111, 'y': 2222, 'z': 3333, 'c': Config(<6 fields...>)},
    'baz': [3, 3, 3, 3, 3, 3, 3],
  },
  'x3': {'foo': <np float64(100, 100)>, 'bar': {<4 items...>}, 'baz': [<7 elements...>]},
  'x4': {'foo': <np float64(100, 100)>, 'bar': {<4 items...>}, 'baz': [<7 elements...>]},
}
```
