### PR TITLE
Show requires_grad info for torch tensors and parameters.

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -16,4 +16,4 @@
 import subprocess
 
 if __name__ == "__main__":
-  subprocess.check_call(["python", "-m", "pytest"])
+  subprocess.check_call(["python", "-m", "pytest", "--tb=short"])


### PR DESCRIPTION
For `Tensor`s, we add requires_grad=True to the summary when that flag is set on the tensor.

For `nn.Parameter`s, we assume gradients are required by default and add requires_grad=False when the parameter is frozen.

Summary shows regardless of whether or not autovizualization is on.

Fixes #51.